### PR TITLE
CMake find_package support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,23 @@ if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_LIBCPP_DEBUG=1")
 endif ()
 
+# Configure package config files.
+set(pkg_config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(project_pkg_config "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+set(version_pkg_config "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${version_pkg_config}" COMPATIBILITY SameMajorVersion)
+configure_package_config_file("cmake/Config.cmake.in" "${project_pkg_config}" INSTALL_DESTINATION "${pkg_config_install_dir}")
+
 add_subdirectory(trng)
 add_subdirectory(examples)
 add_subdirectory(tests)
+
+# Install package config files.
+install(FILES "${project_pkg_config}" "${version_pkg_config}"  DESTINATION "${pkg_config_install_dir}")
+install(EXPORT "${targets_export_name}"
+        DESTINATION "${pkg_config_install_dir}")
 
 find_program(RPMBUILD_FOUND rpmbuild)
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/trng/CMakeLists.txt
+++ b/trng/CMakeLists.txt
@@ -93,7 +93,10 @@ set(SOURCE_FILES
 
 add_library(trng4_static STATIC ${HEADER_FILES} ${SOURCE_FILES})
 set_target_properties(trng4_static PROPERTIES OUTPUT_NAME trng4 CLEAN_DIRECT_OUTPUT 1)
-target_include_directories(trng4_static PUBLIC ..)
+target_include_directories(trng4_static PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+        $<INSTALL_INTERFACE:include>
+        )
 
 if (NOT WIN32)
     add_library(trng4_shared SHARED ${HEADER_FILES} ${SOURCE_FILES})
@@ -101,16 +104,21 @@ if (NOT WIN32)
     set_target_properties(trng4_shared PROPERTIES VERSION ${PROJECT_VERSION})
     set_target_properties(trng4_shared PROPERTIES SOVERSION 24)
     set_target_properties(trng4_shared PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
-    target_include_directories(trng4_shared PUBLIC ..)
+    target_include_directories(trng4_shared PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+            $<INSTALL_INTERFACE:include>
+            )
 endif ()
 
 if (WIN32)
     install(TARGETS trng4_static
+            EXPORT "${targets_export_name}"
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/trng)
 else ()
     install(TARGETS trng4_static trng4_shared
+            EXPORT "${targets_export_name}"
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/trng)


### PR DESCRIPTION
This pull request allows CMake to find an installed trng4 library by using the find_package function. This makes integrating trng4 as a dependency on CMake projects easy and straightforward. After successfully executing find_package(trng4), it is also possible to obtain the found version by consulting the contents of the trng4_VERSION variable.