### PR TITLE
BUILD_SHARED_LIBS support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(OpenMP)
 find_package(TBB)
 
 include_directories(..)
-link_libraries(trng4_static)
+link_libraries(trng4)
 link_directories(${PROJECT_BINARY_DIR}/trng)
 
 add_executable(hello_world hello_world.cc)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,6 @@ if (Boost_FOUND)
     find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
     add_executable(test_all test_all.cc test_engines.cc test_distributions.cc test_math.cc test_int_math.cc type_names.cc test_linear_algebra.cc)
-    target_link_libraries(test_all PUBLIC trng4_static Boost::unit_test_framework)
+    target_link_libraries(test_all PUBLIC trng4 Boost::unit_test_framework)
     add_test(NAME run_test_all COMMAND test_all --log_level=test_suite)
 endif ()

--- a/trng/CMakeLists.txt
+++ b/trng/CMakeLists.txt
@@ -99,6 +99,9 @@ target_include_directories(trng4 PUBLIC
         )
 
 if (BUILD_SHARED_LIBS)
+    if (WIN32)
+        message(FATAL_ERROR "Building a shared library on Windows is not supported.")
+    endif ()
     set_target_properties(trng4 PROPERTIES VERSION ${PROJECT_VERSION})
     set_target_properties(trng4 PROPERTIES SOVERSION 24)
     set_target_properties(trng4 PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")

--- a/trng/CMakeLists.txt
+++ b/trng/CMakeLists.txt
@@ -91,38 +91,24 @@ set(SOURCE_FILES
         yarn5s.cc
         )
 
-add_library(trng4_static STATIC ${HEADER_FILES} ${SOURCE_FILES})
-set_target_properties(trng4_static PROPERTIES OUTPUT_NAME trng4 CLEAN_DIRECT_OUTPUT 1)
-target_include_directories(trng4_static PUBLIC
+add_library(trng4 ${HEADER_FILES} ${SOURCE_FILES})
+set_target_properties(trng4 PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+target_include_directories(trng4 PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
         $<INSTALL_INTERFACE:include>
         )
 
-if (NOT WIN32)
-    add_library(trng4_shared SHARED ${HEADER_FILES} ${SOURCE_FILES})
-    set_target_properties(trng4_shared PROPERTIES OUTPUT_NAME trng4 CLEAN_DIRECT_OUTPUT 1)
-    set_target_properties(trng4_shared PROPERTIES VERSION ${PROJECT_VERSION})
-    set_target_properties(trng4_shared PROPERTIES SOVERSION 24)
-    set_target_properties(trng4_shared PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
-    target_include_directories(trng4_shared PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-            $<INSTALL_INTERFACE:include>
-            )
+if (BUILD_SHARED_LIBS)
+    set_target_properties(trng4 PROPERTIES VERSION ${PROJECT_VERSION})
+    set_target_properties(trng4 PROPERTIES SOVERSION 24)
+    set_target_properties(trng4 PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 endif ()
 
-if (WIN32)
-    install(TARGETS trng4_static
-            EXPORT "${targets_export_name}"
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/trng)
-else ()
-    install(TARGETS trng4_static trng4_shared
-            EXPORT "${targets_export_name}"
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/trng)
-endif ()
+install(TARGETS trng4
+        EXPORT "${targets_export_name}"
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/trng)
 
 find_program(PVS_STUDIO pvs-studio)
 
@@ -131,7 +117,7 @@ if (PVS_STUDIO)
     include(../cmake/PVS-Studio/PVS-Studio.cmake)
 
     pvs_studio_add_target(TARGET ${PROJECT_NAME}.analyze # ALL
-            ANALYZE trng4_static
+            ANALYZE trng4
             OUTPUT FORMAT errorfile
             LOG ${PROJECT_NAME}.err)
 endif ()


### PR DESCRIPTION
This PR implements the feature request described in #24. There is now only a trng4 target, and the user can choose between a static and shared build by using the BUILD_SHARED_LIBS CMake variable. When an user enables BUILD_SHARED_LIBS on Windows an error message will be shown to indicate that this is currently not supported.

I have checked that tests and examples can build and launch successfully with and without BUILD_SHARED_LIBS on Linux, and without BUILD_SHARED_LIBS on Windows. Finding trng4 through find_package is also working. I could not test the change to pvs_studio_add_target as I do not have a license but hopefully it will work fine.